### PR TITLE
Feature/championmain presenter

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -35,5 +35,5 @@ jobs:
           args:
             -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
             -Dsonar.organization=f-lab-edu-1
+            -Dsonar.exclusions=**/LOLInfoApp/LOLInfoAppTests/**
 
-          

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: UnitTest
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Xcode
+      run: |
+       pod install --repo-update --clean-install --project-directory=LOLInfoApp/
+       xcodebuild clean test -workspace LOLInfoApp/LOLInfoApp.xcworkspace -scheme LOLInfoApp -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+
+    - name: Notify Failure on Slack
+      if: failure()
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: |
+            ⚠️⚠️⚠️ 테스트 실패! 에러를 확인해주세요. ⚠️⚠️⚠️
+            에러로그: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		FE5823652B8B91C50085E41E /* ChampionPath.plist in Resources */ = {isa = PBXBuildFile; fileRef = FE5823642B8B91C50085E41E /* ChampionPath.plist */; };
 		FE5823692B8B9D8E0085E41E /* ChampionMainListEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823682B8B9D8E0085E41E /* ChampionMainListEntity.swift */; };
 		FE58236B2B8B9D9B0085E41E /* ChampionMainRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58236A2B8B9D9B0085E41E /* ChampionMainRepository.swift */; };
+		FE58236E2B9DC1930085E41E /* ChampionMainUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58236D2B9DC1930085E41E /* ChampionMainUseCase.swift */; };
+		FE5823702B9DC2310085E41E /* ChampionMainListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */; };
+		FE5823722B9DC35B0085E41E /* FileNameConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823712B9DC35B0085E41E /* FileNameConstants.swift */; };
 		FEA5401A2B864D7800AB6FA2 /* URL.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEA540192B864D7800AB6FA2 /* URL.plist */; };
 		FEA5401C2B864E9C00AB6FA2 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */; };
 /* End PBXBuildFile section */
@@ -44,6 +47,9 @@
 		FE5823642B8B91C50085E41E /* ChampionPath.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ChampionPath.plist; sourceTree = "<group>"; };
 		FE5823682B8B9D8E0085E41E /* ChampionMainListEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChampionMainListEntity.swift; sourceTree = "<group>"; };
 		FE58236A2B8B9D9B0085E41E /* ChampionMainRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChampionMainRepository.swift; sourceTree = "<group>"; };
+		FE58236D2B9DC1930085E41E /* ChampionMainUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainUseCase.swift; sourceTree = "<group>"; };
+		FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChampionMainListViewModel.swift; path = LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainListViewModel.swift; sourceTree = SOURCE_ROOT; };
+		FE5823712B9DC35B0085E41E /* FileNameConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameConstants.swift; sourceTree = "<group>"; };
 		FEA540192B864D7800AB6FA2 /* URL.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = URL.plist; sourceTree = "<group>"; };
 		FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -82,6 +88,7 @@
 			children = (
 				FE5823622B8B8C220085E41E /* StringConstants.swift */,
 				F237D89C2B8EB05E00232F34 /* Bundle+Constants.swift */,
+				FE5823712B9DC35B0085E41E /* FileNameConstants.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -225,6 +232,7 @@
 		FE5823672B8B9D8E0085E41E /* DomainLayer */ = {
 			isa = PBXGroup;
 			children = (
+				FE58236D2B9DC1930085E41E /* ChampionMainUseCase.swift */,
 				FE5823682B8B9D8E0085E41E /* ChampionMainListEntity.swift */,
 			);
 			path = DomainLayer;
@@ -242,6 +250,7 @@
 		FEA540162B836EA200AB6FA2 /* PresentationLayer */ = {
 			isa = PBXGroup;
 			children = (
+				FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */,
 			);
 			path = PresentationLayer;
 			sourceTree = "<group>";
@@ -363,14 +372,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				F2BE13552B7DDD9D0029E980 /* Requestable.swift in Sources */,
+				FE5823702B9DC2310085E41E /* ChampionMainListViewModel.swift in Sources */,
 				FE58236B2B8B9D9B0085E41E /* ChampionMainRepository.swift in Sources */,
 				FEA5401C2B864E9C00AB6FA2 /* Bundle.swift in Sources */,
 				FE5823692B8B9D8E0085E41E /* ChampionMainListEntity.swift in Sources */,
 				FE5823632B8B8C220085E41E /* StringConstants.swift in Sources */,
 				F2BE13532B7DD3E10029E980 /* OSLog.swift in Sources */,
 				F272E2532B7E0CAE00F05B31 /* ChampionMainListDTO.swift in Sources */,
+				FE5823722B9DC35B0085E41E /* FileNameConstants.swift in Sources */,
 				F237D89D2B8EB05E00232F34 /* Bundle+Constants.swift in Sources */,
 				FE26A3ED2B710ED500CF2666 /* AppDelegate.swift in Sources */,
+				FE58236E2B9DC1930085E41E /* ChampionMainUseCase.swift in Sources */,
 				F272E25D2B7E105B00F05B31 /* ChampionAPIEndpoint.swift in Sources */,
 				FE26A3EF2B710ED500CF2666 /* SceneDelegate.swift in Sources */,
 			);

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
@@ -24,9 +24,23 @@
 		FE58236E2B9DC1930085E41E /* ChampionMainUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58236D2B9DC1930085E41E /* ChampionMainUseCase.swift */; };
 		FE5823702B9DC2310085E41E /* ChampionMainListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */; };
 		FE5823722B9DC35B0085E41E /* FileNameConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823712B9DC35B0085E41E /* FileNameConstants.swift */; };
+		FE58237A2B9DD0180085E41E /* LOLInfoAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823792B9DD0170085E41E /* LOLInfoAppTests.swift */; };
+		FE5823862B9DD0CF0085E41E /* MockError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823852B9DD0CF0085E41E /* MockError.swift */; };
+		FE5823892B9DD1030085E41E /* MockChampionMainRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5823882B9DD1030085E41E /* MockChampionMainRepository.swift */; };
+		FE58238B2B9DD1580085E41E /* MockChampionMainListEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */; };
 		FEA5401A2B864D7800AB6FA2 /* URL.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEA540192B864D7800AB6FA2 /* URL.plist */; };
 		FEA5401C2B864E9C00AB6FA2 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FE58237B2B9DD0180085E41E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FE26A3E12B710ED500CF2666 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE26A3E82B710ED500CF2666;
+			remoteInfo = LOLInfoApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		67871AC6812ED22C5DD6D452 /* Pods-LOLInfoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LOLInfoApp.debug.xcconfig"; path = "Target Support Files/Pods-LOLInfoApp/Pods-LOLInfoApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -50,6 +64,11 @@
 		FE58236D2B9DC1930085E41E /* ChampionMainUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainUseCase.swift; sourceTree = "<group>"; };
 		FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChampionMainListViewModel.swift; path = LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainListViewModel.swift; sourceTree = SOURCE_ROOT; };
 		FE5823712B9DC35B0085E41E /* FileNameConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameConstants.swift; sourceTree = "<group>"; };
+		FE5823772B9DD0170085E41E /* LOLInfoAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOLInfoAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FE5823792B9DD0170085E41E /* LOLInfoAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOLInfoAppTests.swift; sourceTree = "<group>"; };
+		FE5823852B9DD0CF0085E41E /* MockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockError.swift; sourceTree = "<group>"; };
+		FE5823882B9DD1030085E41E /* MockChampionMainRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChampionMainRepository.swift; sourceTree = "<group>"; };
+		FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChampionMainListEntity.swift; sourceTree = "<group>"; };
 		FEA540192B864D7800AB6FA2 /* URL.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = URL.plist; sourceTree = "<group>"; };
 		FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,6 +79,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				2DC61154A2A5FCF8BE3C5538 /* Pods_LOLInfoApp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FE5823742B9DD0170085E41E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,6 +148,7 @@
 			isa = PBXGroup;
 			children = (
 				FE26A3EB2B710ED500CF2666 /* LOLInfoApp */,
+				FE5823782B9DD0170085E41E /* LOLInfoAppTests */,
 				FE26A3EA2B710ED500CF2666 /* Products */,
 				EF13FB68FBA4340A81FF0CA8 /* Pods */,
 				25DB05B03DB30208A2FA501B /* Frameworks */,
@@ -132,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				FE26A3E92B710ED500CF2666 /* LOLInfoApp.app */,
+				FE5823772B9DD0170085E41E /* LOLInfoAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -238,6 +266,49 @@
 			path = DomainLayer;
 			sourceTree = "<group>";
 		};
+		FE5823782B9DD0170085E41E /* LOLInfoAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				FE5823842B9DD0BD0085E41E /* Common */,
+				FE5823872B9DD0E10085E41E /* ChampionMain */,
+			);
+			path = LOLInfoAppTests;
+			sourceTree = "<group>";
+		};
+		FE5823822B9DD09F0085E41E /* DomainLayer */ = {
+			isa = PBXGroup;
+			children = (
+				FE5823792B9DD0170085E41E /* LOLInfoAppTests.swift */,
+			);
+			path = DomainLayer;
+			sourceTree = "<group>";
+		};
+		FE5823832B9DD0A90085E41E /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				FE5823882B9DD1030085E41E /* MockChampionMainRepository.swift */,
+				FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		FE5823842B9DD0BD0085E41E /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				FE5823852B9DD0CF0085E41E /* MockError.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		FE5823872B9DD0E10085E41E /* ChampionMain */ = {
+			isa = PBXGroup;
+			children = (
+				FE5823832B9DD0A90085E41E /* Mocks */,
+				FE5823822B9DD09F0085E41E /* DomainLayer */,
+			);
+			path = ChampionMain;
+			sourceTree = "<group>";
+		};
 		FEA540152B836E9000AB6FA2 /* DataLayer */ = {
 			isa = PBXGroup;
 			children = (
@@ -277,6 +348,24 @@
 			productReference = FE26A3E92B710ED500CF2666 /* LOLInfoApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FE5823762B9DD0170085E41E /* LOLInfoAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FE58237F2B9DD0180085E41E /* Build configuration list for PBXNativeTarget "LOLInfoAppTests" */;
+			buildPhases = (
+				FE5823732B9DD0170085E41E /* Sources */,
+				FE5823742B9DD0170085E41E /* Frameworks */,
+				FE5823752B9DD0170085E41E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FE58237C2B9DD0180085E41E /* PBXTargetDependency */,
+			);
+			name = LOLInfoAppTests;
+			productName = LOLInfoAppTests;
+			productReference = FE5823772B9DD0170085E41E /* LOLInfoAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -289,6 +378,10 @@
 				TargetAttributes = {
 					FE26A3E82B710ED500CF2666 = {
 						CreatedOnToolsVersion = 14.0.1;
+					};
+					FE5823762B9DD0170085E41E = {
+						CreatedOnToolsVersion = 14.0.1;
+						TestTargetID = FE26A3E82B710ED500CF2666;
 					};
 				};
 			};
@@ -306,6 +399,7 @@
 			projectRoot = "";
 			targets = (
 				FE26A3E82B710ED500CF2666 /* LOLInfoApp */,
+				FE5823762B9DD0170085E41E /* LOLInfoAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -319,6 +413,13 @@
 				FE26A3F62B710ED600CF2666 /* Assets.xcassets in Resources */,
 				FE5823652B8B91C50085E41E /* ChampionPath.plist in Resources */,
 				FEA5401A2B864D7800AB6FA2 /* URL.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FE5823752B9DD0170085E41E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -388,7 +489,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FE5823732B9DD0170085E41E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE58238B2B9DD1580085E41E /* MockChampionMainListEntity.swift in Sources */,
+				FE5823892B9DD1030085E41E /* MockChampionMainRepository.swift in Sources */,
+				FE5823862B9DD0CF0085E41E /* MockError.swift in Sources */,
+				FE58237A2B9DD0180085E41E /* LOLInfoAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FE58237C2B9DD0180085E41E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FE26A3E82B710ED500CF2666 /* LOLInfoApp */;
+			targetProxy = FE58237B2B9DD0180085E41E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		FE26A3F72B710ED600CF2666 /* LaunchScreen.storyboard */ = {
@@ -572,6 +692,50 @@
 			};
 			name = Release;
 		};
+		FE58237D2B9DD0180085E41E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = L3L2WN7T88;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LOLInfoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LOLInfoApp";
+			};
+			name = Debug;
+		};
+		FE58237E2B9DD0180085E41E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = L3L2WN7T88;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LOLInfoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LOLInfoApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -589,6 +753,15 @@
 			buildConfigurations = (
 				FE26A3FE2B710ED600CF2666 /* Debug */,
 				FE26A3FF2B710ED600CF2666 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FE58237F2B9DD0180085E41E /* Build configuration list for PBXNativeTarget "LOLInfoAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FE58237D2B9DD0180085E41E /* Debug */,
+				FE58237E2B9DD0180085E41E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		FE58238B2B9DD1580085E41E /* MockChampionMainListEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */; };
 		FEA5401A2B864D7800AB6FA2 /* URL.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEA540192B864D7800AB6FA2 /* URL.plist */; };
 		FEA5401C2B864E9C00AB6FA2 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */; };
+		FEDA93A32BB962CC00ADAD9F /* ChampionMainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA93A22BB962CC00ADAD9F /* ChampionMainPresenter.swift */; };
+		FEDA93A82BB964D400ADAD9F /* ChampionMainPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA93A72BB964D400ADAD9F /* ChampionMainPresenterTests.swift */; };
+		FEDA93AA2BB964FF00ADAD9F /* MockChampionMainUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA93A92BB964FF00ADAD9F /* MockChampionMainUseCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +74,9 @@
 		FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChampionMainListEntity.swift; sourceTree = "<group>"; };
 		FEA540192B864D7800AB6FA2 /* URL.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = URL.plist; sourceTree = "<group>"; };
 		FEA5401B2B864E9C00AB6FA2 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
+		FEDA93A22BB962CC00ADAD9F /* ChampionMainPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainPresenter.swift; sourceTree = "<group>"; };
+		FEDA93A72BB964D400ADAD9F /* ChampionMainPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainPresenterTests.swift; sourceTree = "<group>"; };
+		FEDA93A92BB964FF00ADAD9F /* MockChampionMainUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChampionMainUseCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +294,7 @@
 			children = (
 				FE5823882B9DD1030085E41E /* MockChampionMainRepository.swift */,
 				FE58238A2B9DD1580085E41E /* MockChampionMainListEntity.swift */,
+				FEDA93A92BB964FF00ADAD9F /* MockChampionMainUseCase.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -304,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				FE5823832B9DD0A90085E41E /* Mocks */,
+				FEDA93A62BB9649000ADAD9F /* PresentationLayer */,
 				FE5823822B9DD09F0085E41E /* DomainLayer */,
 			);
 			path = ChampionMain;
@@ -322,6 +330,15 @@
 			isa = PBXGroup;
 			children = (
 				FE58236F2B9DC2310085E41E /* ChampionMainListViewModel.swift */,
+				FEDA93A22BB962CC00ADAD9F /* ChampionMainPresenter.swift */,
+			);
+			path = PresentationLayer;
+			sourceTree = "<group>";
+		};
+		FEDA93A62BB9649000ADAD9F /* PresentationLayer */ = {
+			isa = PBXGroup;
+			children = (
+				FEDA93A72BB964D400ADAD9F /* ChampionMainPresenterTests.swift */,
 			);
 			path = PresentationLayer;
 			sourceTree = "<group>";
@@ -472,6 +489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FEDA93A32BB962CC00ADAD9F /* ChampionMainPresenter.swift in Sources */,
 				F2BE13552B7DDD9D0029E980 /* Requestable.swift in Sources */,
 				FE5823702B9DC2310085E41E /* ChampionMainListViewModel.swift in Sources */,
 				FE58236B2B8B9D9B0085E41E /* ChampionMainRepository.swift in Sources */,
@@ -494,9 +512,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				FE58238B2B9DD1580085E41E /* MockChampionMainListEntity.swift in Sources */,
+				FEDA93A82BB964D400ADAD9F /* ChampionMainPresenterTests.swift in Sources */,
 				FE5823892B9DD1030085E41E /* MockChampionMainRepository.swift in Sources */,
 				FE5823862B9DD0CF0085E41E /* MockError.swift in Sources */,
 				FE58237A2B9DD0180085E41E /* LOLInfoAppTests.swift in Sources */,
+				FEDA93AA2BB964FF00ADAD9F /* MockChampionMainUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOLInfoApp/LOLInfoApp/Commons/Constants/FileNameConstants.swift
+++ b/LOLInfoApp/LOLInfoApp/Commons/Constants/FileNameConstants.swift
@@ -1,0 +1,12 @@
+//
+//  FileNameConstants.swift
+//  LOLInfoApp
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Foundation
+
+enum FileNameConstants {
+    static let png: String = ".png"
+}

--- a/LOLInfoApp/LOLInfoApp/Commons/Constants/StringConstants.swift
+++ b/LOLInfoApp/LOLInfoApp/Commons/Constants/StringConstants.swift
@@ -10,4 +10,5 @@ import Foundation
 enum StringConstants {
     static let separator: String = "/"
     static let lineBreak: String = "\n"
+    static let comma: String = ","
 }

--- a/LOLInfoApp/LOLInfoApp/Commons/Extension/Bundle.swift
+++ b/LOLInfoApp/LOLInfoApp/Commons/Extension/Bundle.swift
@@ -28,6 +28,7 @@ extension Bundle {
 extension Bundle {
     enum URLKey: String {
         case baseURL
+        case squareImageURL
     }
     
     static func getURLString(key: URLKey) -> String {

--- a/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainListViewModel.swift
+++ b/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainListViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  ChampionMainListViewModel.swift
+//  LOLInfoApp
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Foundation
+
+struct ChampionMainListViewModel {
+    let nameAndTtitleLabelText: String
+    let roleLabelText: String
+    let imageURLString: String
+
+    init(entity: ChampionMainListEntity.ChampionMainEntity) {
+        nameAndTtitleLabelText = "\(entity.name) • \(entity.title)"
+
+        roleLabelText = entity.roleGroup
+            .map { $0.rawValue }
+            .joined(separator: "\(StringConstants.comma) ")
+
+        let url = Bundle.getURLString(key: .squareImageURL)
+        let fileName = FileNameConstants.png
+        imageURLString = url  + "\(entity.id)" + fileName
+    }
+}

--- a/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainUseCase.swift
+++ b/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainUseCase.swift
@@ -17,7 +17,6 @@ protocol ChampionMainUseCaseDependency {
 //MARK: - UseCase
 
 struct ChampionMainUseCase: ChampionMainUseCaseDependency {
-
     private let repository: ChampionMainRepositoryDependency
 
     init(repository: ChampionMainRepositoryDependency = ChampionMainRepository()) {

--- a/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainUseCase.swift
+++ b/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/DomainLayer/ChampionMainUseCase.swift
@@ -1,0 +1,46 @@
+//
+//  ChampionMainUseCase.swift
+//  LOLInfoApp
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Combine
+import Foundation
+
+// MARK: - Dependency
+
+protocol ChampionMainUseCaseDependency {
+    func getChampionMainListViewModels() -> AnyPublisher<[ChampionMainListViewModel], Error>
+}
+
+//MARK: - UseCase
+
+struct ChampionMainUseCase: ChampionMainUseCaseDependency {
+
+    private let repository: ChampionMainRepositoryDependency
+
+    init(repository: ChampionMainRepositoryDependency = ChampionMainRepository()) {
+        self.repository = repository
+    }
+}
+
+// MARK: - Presenter Use Function
+
+extension ChampionMainUseCase {
+    func getChampionMainListViewModels() -> AnyPublisher<[ChampionMainListViewModel], Error> {
+        return repository.requestAllChampionList()
+            .map { sortByChampionName(model: $0) }
+            .map { $0.map { ChampionMainListViewModel(entity: $0) } }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Helper Function
+
+extension ChampionMainUseCase {
+    private func sortByChampionName(model: ChampionMainListEntity) -> [ChampionMainEntity] {
+        model.championList
+            .sorted { $0.name < $1.name }
+    }
+}

--- a/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/PresentationLayer/ChampionMainPresenter.swift
+++ b/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/PresentationLayer/ChampionMainPresenter.swift
@@ -1,0 +1,75 @@
+//
+//  ChampionMainPresenter.swift
+//  LOLInfoApp
+//
+//  Created by 정덕호 on 3/31/24.
+//
+
+import Combine
+import Foundation
+
+// MARK: - Presenter
+
+final class ChampionMainPresenter {
+    private let useCase: ChampionMainUseCaseDependency
+    private var cancellables: Set<AnyCancellable> = []
+
+
+    init(useCase: ChampionMainUseCaseDependency = ChampionMainUseCase()) {
+        self.useCase = useCase
+    }
+}
+
+// MARK: - Input
+
+extension ChampionMainPresenter {
+    struct Input {
+        let fetchAllChampionList = PassthroughSubject<Void, Never>()
+    }
+}
+
+// MARK: - Output
+
+extension ChampionMainPresenter {
+    struct Output {
+        let mainListViewModels = PassthroughSubject<[ChampionMainListViewModel], Never>()
+        let showRetryAlert = PassthroughSubject<String, Never>()
+        let onOffIndicator = PassthroughSubject<Bool, Never>()
+    }
+}
+
+// MARK: - Transform
+
+extension ChampionMainPresenter {
+    func transform(input: Input) -> Output {
+        let output = Output()
+
+        input.fetchAllChampionList
+            .sink { [weak self] _ in
+                self?.fetchAllChampionList(output: output)
+            }
+            .store(in: &cancellables)
+
+        return output
+    }
+}
+
+// MARK: - Helper Function
+
+extension ChampionMainPresenter {
+    private func fetchAllChampionList(output: Output) {
+        output.onOffIndicator.send(true)
+        useCase.getChampionMainListViewModels()
+            .catch { error in
+                output.showRetryAlert.send(error.localizedDescription)
+                Log.error(error.localizedDescription, error)
+                return Just<[ChampionMainListViewModel]>([])
+            }
+            .sink { viewModel in
+                output.onOffIndicator.send(false)
+                output.mainListViewModels.send(viewModel)
+            }
+            .store(in: &cancellables)
+    }
+}
+

--- a/LOLInfoApp/LOLInfoApp/SupportingFiles/Network/URL.plist
+++ b/LOLInfoApp/LOLInfoApp/SupportingFiles/Network/URL.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>baseURL</key>
 	<string>https://ddragon.leagueoflegends.com/cdn/14.2.1</string>
+	<key>squareImageURL</key>
+	<string>https://ddragon.leagueoflegends.com/cdn/14.3.1/img/champion/</string>
 </dict>
 </plist>

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/DomainLayer/LOLInfoAppTests.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/DomainLayer/LOLInfoAppTests.swift
@@ -1,0 +1,100 @@
+//
+//  LOLInfoAppTests.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import XCTest
+
+import Combine
+import XCTest
+
+@testable import LOLInfoApp
+
+final class ChampionMainUseCaseTests: XCTestCase {
+
+    var useCase: ChampionMainUseCase!
+    var mockRepository: MockChampionMainRepository!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockChampionMainRepository()
+        mockRepository.mockEntity = MockChampionMainListEntity.entity
+        useCase = ChampionMainUseCase(repository: mockRepository)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        mockRepository = nil
+        useCase = nil
+        cancellables = nil
+    }
+
+    func test_getChampionMainListViewModels가ViewModels를_제대로_반환하는지() {
+        //given
+        let expectation = expectation(description: "getChampionMainListViewModels ViewModels")
+        var result: [ChampionMainListViewModel]?
+
+        //when
+        useCase.getChampionMainListViewModels()
+            .sink { _ in
+            } receiveValue: { viewModels in
+                result = viewModels
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        //then
+        wait(for: [expectation], timeout: 1)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result?.isEmpty ?? true)
+    }
+
+    func test_getChampionMainListViewModels가_에러를_제대로_반환하는지() {
+        //given
+        mockRepository.shouldReturnError = true
+        let expectation = expectation(description: "getChampionMainListViewModels")
+        var result: Error?
+
+        //when
+        useCase.getChampionMainListViewModels()
+            .sink { completion in
+                if case let .failure(error) = completion {
+                    result = error
+                    expectation.fulfill()
+                }
+            } receiveValue: { _ in
+            }
+            .store(in: &cancellables)
+
+        //then
+        wait(for: [expectation], timeout: 1)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result as? MockError, MockError.mockError)
+    }
+
+    func test_sortByChampionName이_이름을_가나다_순으로_잘_정렬하는지() {
+        //given
+        let expectation = expectation(description: "sortByChampionName")
+        var result: [ChampionMainListViewModel]?
+
+        //when
+        useCase.getChampionMainListViewModels()
+            .sink { _ in
+            } receiveValue: { viewModels in
+                result = viewModels
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        //then
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(result?[0].nameAndTtitleLabelText ?? "", "가렌 • 데마시아의 힘")
+        XCTAssertEqual(result?[1].nameAndTtitleLabelText ?? "", "아리 • 구미호")
+        XCTAssertEqual(result?[2].nameAndTtitleLabelText ?? "", "헤카림 • 전쟁의 전조")
+    }
+
+}

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainListEntity.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainListEntity.swift
@@ -1,0 +1,27 @@
+//
+//  MockChampionMainListEntity.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Foundation
+
+@testable import LOLInfoApp
+
+enum MockChampionMainListEntity {
+    static let entity = ChampionMainListEntity(championList: [
+        .init(name: "헤카림",
+              title: "전쟁의 전조",
+              id: "Hecarim",
+              roleGroup: [.fighter, .tank]),
+        .init(name: "아리",
+              title: "구미호",
+              id: "Ahri",
+              roleGroup: [.assassin, .mage]),
+        .init(name: "가렌",
+              title: "데마시아의 힘",
+              id: "Garen",
+              roleGroup: [.fighter, .tank])
+    ])
+}

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainRepository.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainRepository.swift
@@ -13,10 +13,8 @@ import Foundation
 // MARK: - Properties
 
 final class MockChampionMainRepository: ChampionMainRepositoryDependency {
-
     var shouldReturnError = false
     var mockEntity: ChampionMainListEntity!
-
 }
 
 // MARK: - Request Function

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainRepository.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainRepository.swift
@@ -1,0 +1,34 @@
+//
+//  MockChampionMainRepository.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Combine
+import Foundation
+
+@testable import LOLInfoApp
+
+// MARK: - Properties
+
+final class MockChampionMainRepository: ChampionMainRepositoryDependency {
+
+    var shouldReturnError = false
+    var mockEntity: ChampionMainListEntity!
+
+}
+
+// MARK: - Request Function
+
+extension MockChampionMainRepository {
+    func requestAllChampionList() -> AnyPublisher<LOLInfoApp.ChampionMainListEntity, Error> {
+        guard shouldReturnError == false else {
+            return Fail(error: MockError.mockError)
+                .eraseToAnyPublisher()
+        }
+        return Just(mockEntity)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainUseCase.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/Mocks/MockChampionMainUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  MockChampionMainUseCase.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 3/31/24.
+//
+
+import Combine
+import Foundation
+@testable import LOLInfoApp
+
+final class MockChampionMainUseCase: ChampionMainUseCaseDependency {
+    var shouldReturnError = false
+    var mockViewModels: [ChampionMainListViewModel]!
+
+    func getChampionMainListViewModels() -> AnyPublisher<[LOLInfoApp.ChampionMainListViewModel], Error> {
+        guard shouldReturnError == false else {
+            return Fail(error: MockError.mockError)
+                .eraseToAnyPublisher()
+        }
+        return Just(mockViewModels)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/LOLInfoApp/LOLInfoAppTests/ChampionMain/PresentationLayer/ChampionMainPresenterTests.swift
+++ b/LOLInfoApp/LOLInfoAppTests/ChampionMain/PresentationLayer/ChampionMainPresenterTests.swift
@@ -1,0 +1,99 @@
+//
+//  ChampionMainPresenterTests.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 3/31/24.
+//
+
+import Combine
+import XCTest
+@testable import LOLInfoApp
+
+final class ChampionMainPresenterTests: XCTestCase {
+    var presenter: ChampionMainPresenter!
+    var mockUseCase: MockChampionMainUseCase!
+    var cancellables: Set<AnyCancellable>!
+    var input: ChampionMainPresenter.Input!
+    var output: ChampionMainPresenter.Output!
+
+    override func setUp() {
+        super.setUp()
+        mockUseCase = MockChampionMainUseCase()
+        let mockViewModels = MockChampionMainListEntity.entity.championList.map {
+            ChampionMainListViewModel(entity: $0)
+        }
+        mockUseCase.mockViewModels = mockViewModels
+        presenter = ChampionMainPresenter(useCase: mockUseCase)
+        input = ChampionMainPresenter.Input()
+        output = presenter.transform(input: input)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        mockUseCase = nil
+        presenter = nil
+        cancellables = nil
+        input = nil
+        output = nil
+    }
+
+    func test_fetchAllChampionList가_정상응답일때_Indicator가_Off되는지() {
+        //given
+        let onOffIndicatorExpectation = expectation(description: "onOffIndicator")
+        var onOffIndicator: [Bool] = []
+
+        //when
+        output.onOffIndicator.sink {
+            onOffIndicator.append($0)
+            guard onOffIndicator.count == 2 else { return }
+            onOffIndicatorExpectation.fulfill()
+        }
+        .store(in: &cancellables)
+
+        input.fetchAllChampionList.send(())
+
+        //then
+        wait(for: [onOffIndicatorExpectation], timeout: 1)
+        XCTAssertEqual(onOffIndicator, [true, false])
+    }
+
+    func test_fetchAllChampionList가_정상응답일때_mainListViewModels가_정상적으로_전달되는지() {
+        //given
+        let mainListViewModelsExpectation = expectation(description: "expectationMainListViewModels")
+        var mainListViewModels: [ChampionMainListViewModel]?
+
+        //when
+        output.mainListViewModels.sink {
+            mainListViewModels = $0
+            mainListViewModelsExpectation.fulfill()
+        }
+        .store(in: &cancellables)
+
+        input.fetchAllChampionList.send(())
+
+        //then
+        wait(for: [mainListViewModelsExpectation], timeout: 1)
+        XCTAssertNotNil(mainListViewModels)
+    }
+
+    func test_fetchAllChampionList가_에러응답일때_ShowRetryAlert에_에러메시지가_전달되는지() {
+        //given
+        mockUseCase.shouldReturnError = true
+        let expectation = expectation(description: "ShowRetryAlert")
+        var errorMessage: String = ""
+
+        //when
+        output.showRetryAlert.sink {
+            errorMessage = $0
+            expectation.fulfill()
+        }
+        .store(in: &cancellables)
+
+        input.fetchAllChampionList.send(())
+
+        //then
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(errorMessage, MockError.mockError.localizedDescription)
+    }
+}

--- a/LOLInfoApp/LOLInfoAppTests/Common/MockError.swift
+++ b/LOLInfoApp/LOLInfoAppTests/Common/MockError.swift
@@ -1,0 +1,12 @@
+//
+//  MockError.swift
+//  LOLInfoAppTests
+//
+//  Created by 정덕호 on 2024/03/10.
+//
+
+import Foundation
+
+enum MockError: Error {
+    case mockError
+}


### PR DESCRIPTION
## issue Number
close #23 

## 작업내용
- Presenter 구현

## PresentationLayer 다이어 그램
<img width="812" alt="스크린샷 2024-03-31 오후 7 05 28" src="https://github.com/f-lab-edu/LOL_Info_App/assets/93653997/1dbc223c-766e-4300-8457-470a1c092e2a">

## 상세 작업내용
### View의 상태 관리와 viewModel 데이터 전달을 담당하는 Presenter 구현
View의 상태를 관리하고 UseCase의 비즈니스 로직을 거친 데이터인 viewModel을 VIew로 전달하는 역할을하는 Presenter를 구현했습니다. 