### PR TITLE
feature/apple-login

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -35,5 +35,4 @@ jobs:
           args:
             -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
             -Dsonar.organization=f-lab-edu-1
-
-          
+            -Dsonar.exclusions=**/LOLInfoApp/AppleSignInTest/**

--- a/LOLInfoApp/AppleSignInTest/AppleSignInTest.swift
+++ b/LOLInfoApp/AppleSignInTest/AppleSignInTest.swift
@@ -1,0 +1,179 @@
+//
+//  AppleSignInTest.swift
+//  AppleSignInTest
+//
+//  Created by Jeong Deokho on 2024/04/09.
+//
+
+import AuthenticationServices
+import Combine
+import XCTest
+
+@testable import LOLInfoApp
+
+final class AppleSignInTest: XCTestCase {
+
+    var credential: MockCredential!
+    var appleSignInManager: MockAppleSignInManager!
+    var authServiceResponseTime: Double!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        credential = MockCredential()
+        appleSignInManager = MockAppleSignInManager(credential: credential)
+        authServiceResponseTime = 3
+        cancellables = []
+    }
+
+    override func tearDown() {
+        credential = nil
+        appleSignInManager = nil
+        authServiceResponseTime = nil
+        cancellables = nil
+    }
+
+    func test_로그인에_성공할때_Entity를_반환하는지() {
+        // given
+        let expectation = expectation(description: "validationEntity")
+        var result: AppleSignInEntity?
+
+        // when
+        appleSignInManager.didSuccessSignIn
+            .sink { _ in
+            } receiveValue: { entity in
+                result = entity
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        appleSignInManager.startSignIn()
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        let firstName = credential.fullName?.givenName ?? ""
+        let lastName = credential.fullName?.familyName ?? ""
+        let successResultName = "\(firstName) \(lastName)"
+        XCTAssertEqual(result?.name, successResultName)
+        XCTAssertEqual(result?.email, credential.email)
+        XCTAssertEqual(result?.userIdentifier, credential.user)
+        cancellables = []
+    }
+
+    func test_로그인에_성공했지만_credential이_유효하지않을때_invalidAppleIDCredential_에러를_반환하는지() {
+        // given
+        let expectation = expectation(description: "invalidAppleIDCredential")
+        var result: AppleSignInError?
+        appleSignInManager.credential = nil
+
+        // when
+        appleSignInManager.didFailSignIn
+            .sink(receiveValue: { error in
+                result = error
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        appleSignInManager.startSignIn()
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        XCTAssertEqual(result, AppleSignInError.invalidAppleIDCredential)
+        cancellables = []
+    }
+
+    func test_로그인에_성공했지만_authorizationCode가_유효하지않을때_invalidAuthorizationData_에러를_반환하는지() {
+        // given
+        let expectation = expectation(description: "invalidAuthorizationData")
+        var result: AppleSignInError?
+        appleSignInManager.credential = MockCredential(authorizationCode: nil)
+
+        // when
+        appleSignInManager.didFailSignIn
+            .sink(receiveValue: { error in
+                result = error
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        appleSignInManager.startSignIn()
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        XCTAssertEqual(result, AppleSignInError.invalidAuthorizationData)
+        cancellables = []
+    }
+
+    func test_로그인에_성공했지만_identityToken가_유효하지않을때_invalidAuthorizationData_에러를_반환하는지() {
+        // given
+        let expectation = expectation(description: "invalidAuthorizationData")
+        var result: AppleSignInError?
+        appleSignInManager.credential = MockCredential(identityToken: nil)
+
+        // when
+        appleSignInManager.didFailSignIn
+            .sink(receiveValue: { error in
+                result = error
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        appleSignInManager.startSignIn()
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        XCTAssertEqual(result, AppleSignInError.invalidAuthorizationData)
+        cancellables = []
+    }
+
+    func test_로그인에실패했을때_에러가_ASAuthorizationError_타입이아닌경우_errorTypeMismatch_에러를_반환하는지() {
+        // given
+        let expectation = expectation(description: "errorTypeMismatch")
+        var result: AppleSignInError?
+        appleSignInManager.appleSignInError = MockError.mock
+
+        // when
+        appleSignInManager.didFailSignIn
+            .sink(receiveValue: { error in
+                result = error
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        appleSignInManager.startSignIn()
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        XCTAssertEqual(result, AppleSignInError.errorTypeMismatch(error: MockError.mock))
+        cancellables = []
+    }
+
+    func test_로그인에실패했을때_에러가_ASAuthorizationError_타입인경우_mapToAppleSignInError로_매핑된_에러를_반환하는지() {
+        // given
+        let expectation = expectation(description: "mapToAppleSignInError")
+        let errorList: [ASAuthorizationError] = [
+            .init(.invalidResponse),
+            .init(.notHandled),
+            .init(.failed),
+            .init(.notInteractive),
+            .init(.canceled),
+            .init(.unknown)
+        ]
+        var result: [AppleSignInError] = []
+
+        // when
+        appleSignInManager.didFailSignIn
+            .sink(receiveValue: { error in
+                result.append(error)
+                guard result.count == errorList.count else { return }
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        errorList.forEach {
+            appleSignInManager.appleSignInError = $0
+            appleSignInManager.startSignIn()
+        }
+
+        // then
+        wait(for: [expectation], timeout: authServiceResponseTime)
+        XCTAssertEqual(
+            result, [.invalidResponse, .notHandled, .failed, .notInteractive, .canceled, .unknown]
+        )
+        cancellables = []
+    }
+}

--- a/LOLInfoApp/AppleSignInTest/Mocks/MockAppleSignInManager.swift
+++ b/LOLInfoApp/AppleSignInTest/Mocks/MockAppleSignInManager.swift
@@ -1,0 +1,31 @@
+//
+//  MockManager.swift
+//  AppleSignInTest
+//
+//  Created by Jeong Deokho on 2024/04/09.
+//
+
+import AuthenticationServices
+import Combine
+
+@testable import LOLInfoApp
+
+final class MockAppleSignInManager: NSObject, AppleSignInManagerDependency {
+    let didFailSignIn = PassthroughSubject<LOLInfoApp.AppleSignInError, Never>()
+    let didSuccessSignIn = PassthroughSubject<AppleSignInEntity, Never>()
+
+    var credential: AppleIDCredentialDependency?
+    var appleSignInError: Error?
+
+    init(credential: AppleIDCredentialDependency) {
+        self.credential = credential
+    }
+
+    func startSignIn() {
+        guard let appleSignInError else {
+            handleSucceedSignIn(credential: credential)
+            return
+        }
+        handleFailedSignIn(error: appleSignInError)
+    }
+}

--- a/LOLInfoApp/AppleSignInTest/Mocks/MockCredential.swift
+++ b/LOLInfoApp/AppleSignInTest/Mocks/MockCredential.swift
@@ -1,0 +1,24 @@
+//
+//  MockCredential.swift
+//  AppleSignInTest
+//
+//  Created by Jeong Deokho on 2024/04/09.
+//
+
+import AuthenticationServices
+import Foundation
+
+@testable import LOLInfoApp
+
+struct MockCredential: AppleIDCredentialDependency {
+    let email: String? = "testEmail@test.com"
+    let fullName: PersonNameComponents? = PersonNameComponents(givenName: "te", familyName: "st")
+    let user: String = "testIdentifier"
+    let authorizationCode: Data?
+    let identityToken: Data?
+
+    init(authorizationCode: Data? = Data(), identityToken: Data? = Data()) {
+        self.authorizationCode = authorizationCode
+        self.identityToken = identityToken
+    }
+}

--- a/LOLInfoApp/AppleSignInTest/Mocks/MockError.swift
+++ b/LOLInfoApp/AppleSignInTest/Mocks/MockError.swift
@@ -1,0 +1,10 @@
+//
+//  MockError.swift
+//  AppleSignInTest
+//
+//  Created by Jeong Deokho on 2024/04/11.
+//
+
+enum MockError: Error {
+    case mock
+}

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/project.pbxproj
@@ -12,12 +12,19 @@
 		F22715922BB6A80E00B498FB /* ChampionMainCollectionViewScetionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22715912BB6A80E00B498FB /* ChampionMainCollectionViewScetionType.swift */; };
 		F237D89D2B8EB05E00232F34 /* Bundle+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F237D89C2B8EB05E00232F34 /* Bundle+Constants.swift */; };
 		F272E2532B7E0CAE00F05B31 /* ChampionMainListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F272E2522B7E0CAE00F05B31 /* ChampionMainListDTO.swift */; };
-		F2BE13532B7DD3E10029E980 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BE13522B7DD3E10029E980 /* OSLog.swift */; };
+		F2773FC92BC3A6EC00630E07 /* AppleSignInManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FC82BC3A6EC00630E07 /* AppleSignInManager.swift */; };
+		F2773FCC2BC3B4E900630E07 /* AppleUserEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FCB2BC3B4E900630E07 /* AppleUserEntity.swift */; };
+		F2773FCE2BC3B9B100630E07 /* AppleSignInError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FCD2BC3B9B100630E07 /* AppleSignInError.swift */; };
+		F2773FD02BC4BDB800630E07 /* AppleSignInManagerDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FCF2BC4BDB800630E07 /* AppleSignInManagerDependency.swift */; };
+		F2773FDF2BC4CCF600630E07 /* AppleSignInTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FDE2BC4CCF600630E07 /* AppleSignInTest.swift */; };
+		F2773FE92BC4CE1900630E07 /* MockAppleSignInManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FE82BC4CE1900630E07 /* MockAppleSignInManager.swift */; };
+		F2773FEB2BC4D0C600630E07 /* MockCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2773FEA2BC4D0C600630E07 /* MockCredential.swift */; };
 		F28816BB2B8EF36000BD0B93 /* ChampionMainCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28816BA2B8EF36000BD0B93 /* ChampionMainCollectionView.swift */; };
 		F2A002562B9ACBE700B69D10 /* ChampionMainFavoriteListLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A002552B9ACBE700B69D10 /* ChampionMainFavoriteListLayoutProvider.swift */; };
 		F2A002582B9ACC3C00B69D10 /* ChampionMainListLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A002572B9ACC3C00B69D10 /* ChampionMainListLayoutProvider.swift */; };
 		F2A0025B2B9AD04400B69D10 /* CompositionalLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A0025A2B9AD04400B69D10 /* CompositionalLayoutProvider.swift */; };
 		F2BE13552B7DDD9D0029E980 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BE13542B7DDD9D0029E980 /* Requestable.swift */; };
+		F2C4B24A2BC7C779003122F7 /* MockError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C4B2492BC7C779003122F7 /* MockError.swift */; };
 		F2D2F9942B9ADA89009812C3 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D2F9932B9ADA89009812C3 /* Bundle.swift */; };
 		F2D2F9962B9ADA8E009812C3 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D2F9952B9ADA8D009812C3 /* OSLog.swift */; };
 		FE26A3ED2B710ED500CF2666 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE26A3EC2B710ED500CF2666 /* AppDelegate.swift */; };
@@ -32,6 +39,16 @@
 		FEA5401A2B864D7800AB6FA2 /* URL.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEA540192B864D7800AB6FA2 /* URL.plist */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		F2773FE02BC4CCF600630E07 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FE26A3E12B710ED500CF2666 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE26A3E82B710ED500CF2666;
+			remoteInfo = LOLInfoApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		148E373A8A2129BF7F8C949F /* Pods-LOLInfoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LOLInfoApp.release.xcconfig"; path = "Target Support Files/Pods-LOLInfoApp/Pods-LOLInfoApp.release.xcconfig"; sourceTree = "<group>"; };
 		4FF80F409D2A5751A884C20E /* Pods-LOLInfoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LOLInfoApp.debug.xcconfig"; path = "Target Support Files/Pods-LOLInfoApp/Pods-LOLInfoApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -41,12 +58,22 @@
 		F22715912BB6A80E00B498FB /* ChampionMainCollectionViewScetionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainCollectionViewScetionType.swift; sourceTree = "<group>"; };
 		F237D89C2B8EB05E00232F34 /* Bundle+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Constants.swift"; sourceTree = "<group>"; };
 		F272E2522B7E0CAE00F05B31 /* ChampionMainListDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainListDTO.swift; sourceTree = "<group>"; };
+		F2773FC72BC38E9F00630E07 /* LOLInfoApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LOLInfoApp.entitlements; sourceTree = "<group>"; };
+		F2773FC82BC3A6EC00630E07 /* AppleSignInManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppleSignInManager.swift; path = LOLInfoApp/Manager/AppleSignIn/AppleSignInManager.swift; sourceTree = SOURCE_ROOT; };
+		F2773FCB2BC3B4E900630E07 /* AppleUserEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUserEntity.swift; sourceTree = "<group>"; };
+		F2773FCD2BC3B9B100630E07 /* AppleSignInError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInError.swift; sourceTree = "<group>"; };
+		F2773FCF2BC4BDB800630E07 /* AppleSignInManagerDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInManagerDependency.swift; sourceTree = "<group>"; };
+		F2773FDC2BC4CCF600630E07 /* AppleSignInTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppleSignInTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2773FDE2BC4CCF600630E07 /* AppleSignInTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInTest.swift; sourceTree = "<group>"; };
+		F2773FE82BC4CE1900630E07 /* MockAppleSignInManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppleSignInManager.swift; sourceTree = "<group>"; };
+		F2773FEA2BC4D0C600630E07 /* MockCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCredential.swift; sourceTree = "<group>"; };
 		F28816BA2B8EF36000BD0B93 /* ChampionMainCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainCollectionView.swift; sourceTree = "<group>"; };
 		F2A002552B9ACBE700B69D10 /* ChampionMainFavoriteListLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainFavoriteListLayoutProvider.swift; sourceTree = "<group>"; };
 		F2A002572B9ACC3C00B69D10 /* ChampionMainListLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChampionMainListLayoutProvider.swift; sourceTree = "<group>"; };
 		F2A0025A2B9AD04400B69D10 /* CompositionalLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionalLayoutProvider.swift; sourceTree = "<group>"; };
 		F2BE13522B7DD3E10029E980 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		F2BE13542B7DDD9D0029E980 /* Requestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
+		F2C4B2492BC7C779003122F7 /* MockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockError.swift; sourceTree = "<group>"; };
 		F2D2F9932B9ADA89009812C3 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		F2D2F9952B9ADA8D009812C3 /* OSLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		FE26A3E92B710ED500CF2666 /* LOLInfoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LOLInfoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +92,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F2773FD92BC4CCF600630E07 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FE26A3E62B710ED500CF2666 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -136,6 +170,36 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		F2773FCA2BC3B4CF00630E07 /* AppleSignIn */ = {
+			isa = PBXGroup;
+			children = (
+				F2773FCF2BC4BDB800630E07 /* AppleSignInManagerDependency.swift */,
+				F2773FC82BC3A6EC00630E07 /* AppleSignInManager.swift */,
+				F2773FCB2BC3B4E900630E07 /* AppleUserEntity.swift */,
+				F2773FCD2BC3B9B100630E07 /* AppleSignInError.swift */,
+			);
+			path = AppleSignIn;
+			sourceTree = "<group>";
+		};
+		F2773FDD2BC4CCF600630E07 /* AppleSignInTest */ = {
+			isa = PBXGroup;
+			children = (
+				F2773FE52BC4CD0F00630E07 /* Mocks */,
+				F2773FDE2BC4CCF600630E07 /* AppleSignInTest.swift */,
+			);
+			path = AppleSignInTest;
+			sourceTree = "<group>";
+		};
+		F2773FE52BC4CD0F00630E07 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				F2C4B2492BC7C779003122F7 /* MockError.swift */,
+				F2773FEA2BC4D0C600630E07 /* MockCredential.swift */,
+				F2773FE82BC4CE1900630E07 /* MockAppleSignInManager.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		F28816B92B8EF1E900BD0B93 /* CollectionView */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				FE26A3EB2B710ED500CF2666 /* LOLInfoApp */,
+				F2773FDD2BC4CCF600630E07 /* AppleSignInTest */,
 				FE26A3EA2B710ED500CF2666 /* Products */,
 				1836AE3F7B044CD5AFE9C5B1 /* Pods */,
 				256D0F82EF42589CCD24D097 /* Frameworks */,
@@ -196,6 +261,7 @@
 			isa = PBXGroup;
 			children = (
 				FE26A3E92B710ED500CF2666 /* LOLInfoApp.app */,
+				F2773FDC2BC4CCF600630E07 /* AppleSignInTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -203,6 +269,7 @@
 		FE26A3EB2B710ED500CF2666 /* LOLInfoApp */ = {
 			isa = PBXGroup;
 			children = (
+				F2773FC72BC38E9F00630E07 /* LOLInfoApp.entitlements */,
 				FE26A4042B711B3F00CF2666 /* Application */,
 				FE26A4072B711B6500CF2666 /* SupportingFiles */,
 				FE26A4062B711B5900CF2666 /* Resources */,
@@ -259,9 +326,9 @@
 		FE26A4092B711C0500CF2666 /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				F207C97D2B8DB6DB009CE6CB /* PresentationLayer */,
 				FE5823672B8B9D8E0085E41E /* DomainLayer */,
 				FEA540152B836E9000AB6FA2 /* DataLayer */,
-				F207C97D2B8DB6DB009CE6CB /* PresentationLayer */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -269,6 +336,7 @@
 		FE26A40B2B711CA600CF2666 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				F2773FCA2BC3B4CF00630E07 /* AppleSignIn */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -313,6 +381,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		F2773FDB2BC4CCF600630E07 /* AppleSignInTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F2773FE22BC4CCF600630E07 /* Build configuration list for PBXNativeTarget "AppleSignInTest" */;
+			buildPhases = (
+				F2773FD82BC4CCF600630E07 /* Sources */,
+				F2773FD92BC4CCF600630E07 /* Frameworks */,
+				F2773FDA2BC4CCF600630E07 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F2773FE12BC4CCF600630E07 /* PBXTargetDependency */,
+			);
+			name = AppleSignInTest;
+			productName = AppleSignInTest;
+			productReference = F2773FDC2BC4CCF600630E07 /* AppleSignInTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		FE26A3E82B710ED500CF2666 /* LOLInfoApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FE26A3FD2B710ED600CF2666 /* Build configuration list for PBXNativeTarget "LOLInfoApp" */;
@@ -339,9 +425,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1400;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					F2773FDB2BC4CCF600630E07 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = FE26A3E82B710ED500CF2666;
+					};
 					FE26A3E82B710ED500CF2666 = {
 						CreatedOnToolsVersion = 14.0.1;
 					};
@@ -361,11 +451,19 @@
 			projectRoot = "";
 			targets = (
 				FE26A3E82B710ED500CF2666 /* LOLInfoApp */,
+				F2773FDB2BC4CCF600630E07 /* AppleSignInTest */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		F2773FDA2BC4CCF600630E07 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FE26A3E72B710ED500CF2666 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -422,18 +520,33 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F2773FD82BC4CCF600630E07 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F2773FE92BC4CE1900630E07 /* MockAppleSignInManager.swift in Sources */,
+				F2773FDF2BC4CCF600630E07 /* AppleSignInTest.swift in Sources */,
+				F2C4B24A2BC7C779003122F7 /* MockError.swift in Sources */,
+				F2773FEB2BC4D0C600630E07 /* MockCredential.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FE26A3E52B710ED500CF2666 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F2773FC92BC3A6EC00630E07 /* AppleSignInManager.swift in Sources */,
 				F2BE13552B7DDD9D0029E980 /* Requestable.swift in Sources */,
 				F2D2F9942B9ADA89009812C3 /* Bundle.swift in Sources */,
+				F2773FD02BC4BDB800630E07 /* AppleSignInManagerDependency.swift in Sources */,
 				FE58236B2B8B9D9B0085E41E /* ChampionMainRepository.swift in Sources */,
+				F2773FCC2BC3B4E900630E07 /* AppleUserEntity.swift in Sources */,
 				FE5823692B8B9D8E0085E41E /* ChampionMainListEntity.swift in Sources */,
 				FE5823632B8B8C220085E41E /* StringConstants.swift in Sources */,
 				F272E2532B7E0CAE00F05B31 /* ChampionMainListDTO.swift in Sources */,
 				F2D2F9962B9ADA8E009812C3 /* OSLog.swift in Sources */,
 				F237D89D2B8EB05E00232F34 /* Bundle+Constants.swift in Sources */,
+				F2773FCE2BC3B9B100630E07 /* AppleSignInError.swift in Sources */,
 				FE26A3F12B710ED500CF2666 /* ChampionMainViewController.swift in Sources */,
 				F207C9812B8DB787009CE6CB /* UIColor.swift in Sources */,
 				FE26A3ED2B710ED500CF2666 /* AppDelegate.swift in Sources */,
@@ -449,6 +562,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		F2773FE12BC4CCF600630E07 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FE26A3E82B710ED500CF2666 /* LOLInfoApp */;
+			targetProxy = F2773FE02BC4CCF600630E07 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		FE26A3F72B710ED600CF2666 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -461,6 +582,53 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		F2773FE32BC4CCF600630E07 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = G42AKFB24M;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = LoLInfoApp.AppleSignInTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LOLInfoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LOLInfoApp";
+			};
+			name = Debug;
+		};
+		F2773FE42BC4CCF600630E07 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = G42AKFB24M;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = LoLInfoApp.AppleSignInTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LOLInfoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LOLInfoApp";
+			};
+			name = Release;
+		};
 		FE26A3FB2B710ED600CF2666 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -581,9 +749,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LOLInfoApp/LOLInfoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G42AKFB24M;
+				DEVELOPMENT_TEAM = V53Z7HF8ZQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LOLInfoApp/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -595,7 +764,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoAppssss;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -609,9 +778,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LOLInfoApp/LOLInfoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G42AKFB24M;
+				DEVELOPMENT_TEAM = V53Z7HF8ZQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LOLInfoApp/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -623,7 +793,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeokHo98.LOLInfoAppssss;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -634,6 +804,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		F2773FE22BC4CCF600630E07 /* Build configuration list for PBXNativeTarget "AppleSignInTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F2773FE32BC4CCF600630E07 /* Debug */,
+				F2773FE42BC4CCF600630E07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FE26A3E42B710ED500CF2666 /* Build configuration list for PBXProject "LOLInfoApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/xcshareddata/xcschemes/LOLInfoApp.xcscheme
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/xcshareddata/xcschemes/LOLInfoApp.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FE26A3E82B710ED500CF2666"
+               BuildableName = "LOLInfoApp.app"
+               BlueprintName = "LOLInfoApp"
+               ReferencedContainer = "container:LOLInfoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F2773FDB2BC4CCF600630E07"
+               BuildableName = "AppleSignInTest.xctest"
+               BlueprintName = "AppleSignInTest"
+               ReferencedContainer = "container:LOLInfoApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FE26A3E82B710ED500CF2666"
+            BuildableName = "LOLInfoApp.app"
+            BlueprintName = "LOLInfoApp"
+            ReferencedContainer = "container:LOLInfoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FE26A3E82B710ED500CF2666"
+            BuildableName = "LOLInfoApp.app"
+            BlueprintName = "LOLInfoApp"
+            ReferencedContainer = "container:LOLInfoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LOLInfoApp/LOLInfoApp.xcodeproj/xcuserdata/jeongdeokho.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/LOLInfoApp/LOLInfoApp.xcodeproj/xcuserdata/jeongdeokho.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,18 @@
 			<integer>4</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>F2773FDB2BC4CCF600630E07</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>FE26A3E82B710ED500CF2666</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/LOLInfoApp/LOLInfoApp.xcworkspace/xcuserdata/jeongdeokho.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/LOLInfoApp/LOLInfoApp.xcworkspace/xcuserdata/jeongdeokho.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "173CDA43-9861-4938-9BAC-8BEA621313B9"
+   type = "0"
+   version = "2.0">
+</Bucket>

--- a/LOLInfoApp/LOLInfoApp/LOLInfoApp.entitlements
+++ b/LOLInfoApp/LOLInfoApp/LOLInfoApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInError.swift
+++ b/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInError.swift
@@ -1,0 +1,107 @@
+//
+//  AppleSignInError.swift
+//  LOLInfoApp
+//
+//  Created by Jeong Deokho on 2024/04/08.
+//
+
+import AuthenticationServices
+
+enum AppleSignInError: Error {
+
+    private enum ErrorDescription {
+        static let invalidAccount = "잘못된 애플 계정입니다."
+        static let failedLogin = "로그인에 실패했습니다. 계속해서 문제 발생시 고객센터로 문의 부탁드립니다."
+        static let canceledLogin = "로그인을 취소하였습니다."
+    }
+
+    /// AppleIDCredential이  유효하지않은경우 에러
+    case invalidAppleIDCredential
+
+    /// 로그인에 필요한 code와 토큰이 유효하지않은경우 에러
+    case invalidAuthorizationData
+
+    /// 에러 타입이 ASAuthorizationError가 아닌경우 에러
+    case errorTypeMismatch(error: Error?)
+
+    /// 로그인 승인 응답이 잘못 됐을경우 에러
+    case invalidResponse
+
+    /// 로그인 승인 요청이 처리되지 않았을때 에러
+    case notHandled
+
+    /// 로그인 시도가 실패했을때 에러
+    case failed
+
+    /// 자동인증 시나리오에서 실패했을때 에러 (ex: 생체인증)
+    case notInteractive
+
+    /// 사용자가 로그인을 취소했을때 에러
+    case canceled
+
+    /// 알수없는 에러
+    case unknown
+}
+
+// MARK: - ASAuthorizationError to AppleSignInError Mapping Function
+
+extension AppleSignInError {
+    static func mapToAppleSignInError(errorCode: ASAuthorizationError.Code) -> Self {
+        switch errorCode {
+        case .invalidResponse:
+            return .invalidResponse
+        case .notHandled:
+            return .notHandled
+        case .failed:
+            return .failed
+        case .notInteractive:
+            return .notInteractive
+        case .canceled:
+            return .canceled
+        case .unknown:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+}
+
+// MARK: - Error Description
+
+extension AppleSignInError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidAppleIDCredential, .invalidAuthorizationData:
+            return ErrorDescription.invalidAccount
+        case .errorTypeMismatch(let error):
+            return error?.localizedDescription
+        case .invalidResponse, .notHandled, .failed, .notInteractive, .unknown:
+            return ErrorDescription.failedLogin
+        case .canceled:
+            return ErrorDescription.canceledLogin
+        }
+    }
+}
+
+// MARK: - Equatable
+
+extension AppleSignInError: Equatable {
+    // 해당코드는 .errorTypeMismatch의 비교 테스트 코드를 위해 필요한 코드입니다
+    static func == (lhs: AppleSignInError, rhs: AppleSignInError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidAppleIDCredential, .invalidAppleIDCredential),
+             (.invalidAuthorizationData, .invalidAuthorizationData),
+             (.invalidResponse, .invalidResponse),
+             (.notHandled, .notHandled),
+             (.failed, .failed),
+             (.notInteractive, .notInteractive),
+             (.canceled, .canceled),
+             (.unknown, .unknown):
+            return true
+        case (.errorTypeMismatch(let lhsError), .errorTypeMismatch(let rhsError)):
+            return lhsError?.localizedDescription == rhsError?.localizedDescription
+        default:
+            return false
+        }
+    }
+}

--- a/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInManager.swift
+++ b/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInManager.swift
@@ -1,0 +1,44 @@
+//
+//  AppleSignInManager.swift
+//  LOLInfoApp
+//
+//  Created by Jeong Deokho on 2024/04/08.
+//
+
+import AuthenticationServices
+import Combine
+
+// MARK: - AppleSignInManager
+
+final class AppleSignInManager: NSObject, AppleSignInManagerDependency {
+    let didFailSignIn = PassthroughSubject<AppleSignInError, Never>()
+    let didSuccessSignIn = PassthroughSubject<AppleSignInEntity, Never>()
+
+    func startSignIn() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.performRequests()
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleSignInManager: ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        let credential = authorization.credential as? ASAuthorizationAppleIDCredential
+        handleSucceedSignIn(credential: credential)
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        handleFailedSignIn(error: error)
+    }
+}

--- a/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInManagerDependency.swift
+++ b/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleSignInManagerDependency.swift
@@ -1,0 +1,77 @@
+//
+//  AppleSignInDependency.swift
+//  LOLInfoApp
+//
+//  Created by Jeong Deokho on 2024/04/09.
+//
+
+import AuthenticationServices
+import Combine
+
+// MARK: - Dependency
+
+protocol AppleSignInManagerDependency {
+    var didSuccessSignIn: PassthroughSubject<AppleSignInEntity, Never> { get }
+    var didFailSignIn: PassthroughSubject<AppleSignInError, Never> { get }
+
+    func startSignIn()
+}
+
+// MARK: - DidComplete Function
+
+extension AppleSignInManagerDependency {
+    /// 애플로그인에 성공했을때의 처리를 담당하는 함수입니다.
+    func handleSucceedSignIn(credential: AppleIDCredentialDependency?) {
+        guard let credential else {
+            didFailSignIn.send(.invalidAppleIDCredential)
+            return
+        }
+        guard let authorizationCode = credential.authorizationCode,
+              let identityToken = credential.identityToken else {
+            didFailSignIn.send(.invalidAuthorizationData)
+            return
+        }
+        let entity = getAppleSignInEntity(credential: credential,
+                                          authorizationCode: authorizationCode,
+                                          identityToken: identityToken)
+        didSuccessSignIn.send(entity)
+    }
+
+    /// 애플로그인에 실패했을때의 처리를 담당하는 함수입니다.
+    func handleFailedSignIn(error: Error?) {
+        guard let error = error as? ASAuthorizationError else {
+            return didFailSignIn.send(.errorTypeMismatch(error: error))
+        }
+        didFailSignIn.send(AppleSignInError.mapToAppleSignInError(errorCode: error.code))
+    }
+
+    /// 애플로그인에 필요한 Entity를 생성하는 함수입니다.
+    private func getAppleSignInEntity(
+        credential: AppleIDCredentialDependency,
+        authorizationCode: Data,
+        identityToken: Data
+    ) -> AppleSignInEntity {
+        let firstName = credential.fullName?.givenName ?? ""
+        let lastName = credential.fullName?.familyName ?? ""
+        return AppleSignInEntity(
+            email: credential.email ?? "",
+            name: "\(firstName) \(lastName)",
+            userIdentifier: credential.user,
+            authorizationCode: authorizationCode,
+            identityToken: identityToken
+        )
+    }
+}
+
+// MARK: - ASAuthorizationAppleIDCredential Dependency
+
+// ASAuthorizationAppleIDCredential를 상속받아 Mock객체를 구현하는게 불가능하기때문에 Mock객체구현을 위한 프로토콜 입니다.
+protocol AppleIDCredentialDependency {
+    var authorizationCode: Data? { get }
+    var identityToken: Data? { get }
+    var fullName: PersonNameComponents? { get }
+    var email: String? { get }
+    var user: String { get }
+}
+
+extension ASAuthorizationAppleIDCredential: AppleIDCredentialDependency {}

--- a/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleUserEntity.swift
+++ b/LOLInfoApp/LOLInfoApp/Manager/AppleSignIn/AppleUserEntity.swift
@@ -1,0 +1,16 @@
+//
+//  AppleSignInEntity.swift
+//  LOLInfoApp
+//
+//  Created by Jeong Deokho on 2024/04/08.
+//
+
+import Foundation
+
+struct AppleSignInEntity {
+    let email: String
+    let name: String
+    let userIdentifier: String
+    let authorizationCode: Data
+    let identityToken: Data
+}

--- a/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/PresentationLayer/ChampionMainViewController.swift
+++ b/LOLInfoApp/LOLInfoApp/Scenes/Champion/Main/PresentationLayer/ChampionMainViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-
 import SnapKit
 
 final class ChampionMainViewController: UIViewController {


### PR DESCRIPTION
## issue Number
close #31 

## 애플로그인 과정 다이어그램
<img width="1223" alt="스크린샷 2024-04-11 오후 3 45 38" src="https://github.com/f-lab-edu/LOL_Info_App/assets/93653997/befc52a3-1a49-40d2-b376-fa77bf006500">

## 작업내용
- 애플로그인 프레임워크를 통해 사용자 검증에 필요한 데이터를 받아오는데 까지 구현 (다이어그램 2번까지 구현)
- 애플로그인 테스트코드 작성

## 로그인 결과 
<img width="507" alt="스크린샷 2024-04-11 오후 4 12 31" src="https://github.com/f-lab-edu/LOL_Info_App/assets/93653997/cfd1de8e-6740-48a9-899d-4b0cd5d91e7a">

![스크린샷 2024-04-11 오후 4 01 18](https://github.com/f-lab-edu/LOL_Info_App/assets/93653997/2e9ef130-cc8c-4aeb-b73f-e44fa20ae4a0)